### PR TITLE
save path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
 
 # rtp_h264_extractor
 
-Dump RTP h.264 payload to raw h.264 file (*.264)  
-According to RFC3984 to dissector H264 payload of RTP to NALU, and write it to from<sourceIp_sourcePort>to<dstIp_dstPort>.264 file. By now, we support single NALU, STAP-A and FU-A format RTP payload for H.264.  
-You can access this feature by menu "Tools->Export H264 to file [HQX's plugins]"  
+## wireshark lua脚本位置
 
-Author: Huang Qiangxiong (qiangxiong.huang@gmail.com)
+mac下：
+
+	/Applications/Wireshark.app/Contents/Resources/share/wireshark/
+
+
+下文记做{wireshark-lua-dir}
+
+
+## 安装rtp_h264_extractor插件
+
+
+1. 将rtp_h264_extractor，拷贝到{wireshark-lua-dir}
+
+2. 修改{wireshark-lua-dir}/init.lua文件，脚本结尾添加如下
+
+
+	dofile(DATA_DIR.."rtp_h264_extractor.lua")
+
+
+3. 添加环境变量WIRESHARK_H264_PATH,作用：录音文件的存储位置。
+
+
+## 使用
+
+在wireshark->tools菜单下会新加一功能项“Export H264 to file”

--- a/rtp_h264_extractor.lua
+++ b/rtp_h264_extractor.lua
@@ -29,7 +29,7 @@ do
     --local bit = require("bit32") -- only work after 1.10.1 (only support in Lua 5.2)  
     local version_str = string.match(_VERSION, "%d+[.]%d*")  
     local version_num = version_str and tonumber(version_str) or 5.1  
-    local bit = (version_num >= 5.2) and require("bit32") or require("bit")  
+    local bit = (version_num >= 5.2) and require("bit32") or require("bit") 
   
     -- for geting h264 data (the field's value is type of ByteArray)  
     local f_h264 = Field.new("h264")   
@@ -85,8 +85,23 @@ do
             key = key:gsub(":", ".")  
             local stream_info = stream_infos[key]  
             if not stream_info then -- if not exists, create one  
-                stream_info = { }  
-                stream_info.filename = key.. ".264"  
+                stream_info = { }
+
+                local save_path = os.getenv("WIRESHARK_H264_PATH")
+                if  not save_path then
+                    -- check dir exists, before
+                    local file = io.open(save_dir, "rb")
+                    if file then 
+                        file:close()
+                    else
+                        os.execute("mkdir -p " .. save_dir) 
+                    end
+
+                    stream_info.filename = save_dir .. "/" .. key .. ".264"  
+                else
+                    stream_info.filename = key .. ".264"
+                end
+
                 stream_info.file = io.open(stream_info.filename, "wb")  
                 stream_info.counter = 0 -- counting h264 total NALUs  
                 stream_info.counter2 = 0 -- for second time running  


### PR DESCRIPTION
添加WIRESHARK_H264_PATH环境变量，控制录像文件位置，而不是永远保存在wireshark启动时的某个'./'下。